### PR TITLE
Enable metrics by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,3 @@ ADD keydb.conf /etc/
 
 # Run with Prometheus stats exporter
 CMD ["/fly/hivemind", "/fly/Procfile"]
-
-# Run without Prometheus
-# CMD ["/fly/start_keydb.sh"]

--- a/fly.toml
+++ b/fly.toml
@@ -4,3 +4,6 @@ app = "keydb-multimaster-example"
 source = "keydb_server"
 destination = "/data"
 
+[metrics]
+  port = 9121
+  path = "/metrics"


### PR DESCRIPTION
When testing out KeyDB I copied the metrics config from the Redis
documentation which uses a non-standard port for the redis_exporter
(9091). By adding it to fly.toml hopefully we can keep other people from
running into it.

I also removed the commented out config from the Dockerfile as it looks
like there are other tasks (detect_peers.sh) which need to be run so
using that config could have broken multi master deploys.